### PR TITLE
[CRASH] Patch to work around WSOD when enabling layout builder

### DIFF
--- a/composer.patches.json
+++ b/composer.patches.json
@@ -1,4 +1,7 @@
 {
   "patches": {
+     "drupal/core": {
+       "Workaround for WSOD 'Call to a member function getLabel()' after enabling layout_builder": "https://www.drupal.org/files/issues/2020-04-08/2985882-field-85.patch" 
+     }
   }
 }


### PR DESCRIPTION
Adding the patch from comment #85 on https://www.drupal.org/project/drupal/issues/2985882